### PR TITLE
Rewrite resident key option handling as switch statements

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1138,19 +1138,32 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
 
                   1. If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{authenticatorAttachment}}</code> is
                     [=present|present=] and its value is not equal to |authenticator|'s [=authenticator attachment modality=], [=iteration/continue=].
-                  1. If ( <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code> is set to
-                    {{ResidentKeyRequirement/required}} or <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{requireResidentKey}}</code> 
-                    is set to [TRUE] ) and the |authenticator| is not capable of storing a [=client-side-resident public key credential source=],
-                    [=iteration/continue=].
-                    ::  Note:  The value of <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{requireResidentKey}}</code> is to be ignored
-                        if a value for <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code> is supplied.
-                  1. If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code> is set to
-                    {{ResidentKeyRequirement/forbidden}} and the |authenticator| is ONLY capable of storing a [=client-side-resident public key credential source=],
-                    [=iteration/continue=].
-                  1. If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code> is set to
-                    {{ResidentKeyRequirement/preferred}} and the |authenticator| is not capable of storing a [=client-side-resident public key credential source=],
-                    and there are other known authenticators attached that are capable of storing a [=client-side-resident public key credential source=],
-                    [=iteration/continue=].
+
+                  1. If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code>
+
+                      <dl class="switch">
+                          :   is set to {{ResidentKeyRequirement/required}}
+                          ::  If the |authenticator| is not capable of storing a [=client-side-resident public key credential
+                              source=], [=iteration/continue=].
+
+                          :   is set to {{ResidentKeyRequirement/preferred}}
+                          ::  If the |authenticator| is not capable of storing a [=client-side-resident public key credential
+                              source=], and there are other known authenticators attached that are capable of storing a
+                              [=client-side-resident public key credential source=], [=iteration/continue=].
+
+                          :   is set to {{ResidentKeyRequirement/indifferent}}
+                          ::  No effect.
+
+                          :   is set to {{ResidentKeyRequirement/forbidden}}
+                          ::  If the |authenticator| is ONLY capable of storing a [=client-side-resident public key credential
+                              source=], [=iteration/continue=].
+
+                          :   is [=not present=]
+                          ::  if <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{requireResidentKey}}</code>
+                              is set to [TRUE] and the |authenticator| is not capable of storing a [=client-side-resident public
+                              key credential source=], [=iteration/continue=].
+                      </dl>
+
                   1. If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{AuthenticatorSelectionCriteria/userVerification}}</code> is
                     set to {{UserVerificationRequirement/required}} and the |authenticator| is not capable of performing [=user
                     verification=], [=iteration/continue=].
@@ -1158,7 +1171,7 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
             1. Let |requireResidentKey| be the <dfn>effective resident key requirement for credential creation</dfn>, a Boolean value,
                 as follows. 
 
-                If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code> is supplied and its value:
+                If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code>
 
                     <dl class="switch">
 
@@ -1180,13 +1193,15 @@ a numbered step. If outdented, it (today) is rendered as a bullet in the midst o
                         :   is set to {{ResidentKeyRequirement/required}}
                         ::  Let |requireResidentKey| be [TRUE].
 
+                        :   is [=not present=]
+                        ::  If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{requireResidentKey}}</code>
+                                is [=present=], let |requireResidentKey| be the value of
+                                <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{requireResidentKey}}</code>.
+                                If
+                                <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{requireResidentKey}}</code>
+                                is [=not present=], let |requireResidentKey| be [FALSE].
+
                     </dl>
-
-                If <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{residentKey}}</code> is not supplied and
-                <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{requireResidentKey}}</code> is supplied then
-                let |requireResidentKey| be the value of 
-                <code>|options|.{{PublicKeyCredentialCreationOptions/authenticatorSelection}}.{{requireResidentKey}}</code>.
-
 
             1. Let |userVerification| be the <dfn>effective user verification requirement for credential creation</dfn>, a Boolean value,
                 as follows. If


### PR DESCRIPTION
See https://github.com/w3c/webauthn/pull/1191#discussion_r268650700

The issues with `forbidden` I pointed out in https://github.com/w3c/webauthn/issues/991#issuecomment-476693460 remain, though.